### PR TITLE
Add Bluedog_DB to Mod support

### DIFF
--- a/Mod Support/Bluedog_DB.cfg
+++ b/Mod Support/Bluedog_DB.cfg
@@ -1,0 +1,289 @@
+//Bluedog_DB
+//
+//Hide Legacy Parts
+//*********************** Tier 1 ***********************
+//structures0
+//start
+//*********************** Tier2 ***********************
+//basicRocketry
+//structures1
+//fabrication
+//flight1
+//aeronautics
+//engineering101
+//*********************** Tier 3 ***********************
+//generalRocketry
+//structures1p5
+//basicConstruction
+//earlyAviation
+//stability
+//survivability
+//gadgets
+//*********************** Tier 4 ***********************
+//advRocketry
+@PART[bluedog_Atlas_LR101_*|bluedog_Atlas_LR105|bluedog_Atlas_LR89|bluedog_mercury_posigradeMotor|bluedog_mercurySRB|bluedog_redstone]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = advRocketry
+}
+//customFuelTanks
+@PART[bluedog_Atlas_AdapterFuelTank|bluedog_Atlas_LongFuelTank|bluedog_Atlas_MediumFuelTank|bluedog_Atlas_ShortAdapterTank|bluedog_Atlas_ShortFuelTank|bluedog_Atlas_SustainerAdapterTank|bluedog_RedstoneLongTank|bluedog_RedstoneShortTank]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = customFuelTanks
+}
+//generalConstruction
+@PART[bluedog_Atlas_BoosterSkirt|bluedog_Atlas_Decoupler1875m|bluedog_mercuryLES]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = generalConstruction
+}
+//aviation
+@PART[bluedog_Atlas_FairingBase|bluedog_redstoneCS]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = aviation
+}
+//flightControl
+@PART[bluedog_Atlas2_RollControlSystem|bluedog_mercuryRCS]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = flightControl
+}
+//reentryPods1
+@PART[bluedog_mercuryPod]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = reentryPods1
+}
+//enhancedSurvivability
+@PART[bluedog_mercuryHeatshield]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = enhancedSurvivability
+}
+//basicScience
+@PART[bluedog_mercuryScience]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = basicScience
+}
+//gizmos
+//*********************** Tier 5 *********************** 
+//propulsionSystems
+@PART[bluedog_Gemini_LES]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = propulsionSystems
+}
+//heavyRocketry
+//fuelSystems
+//structures2
+@PART[bluedog_CELV_AdapterTank_2p5m_*|bluedog_Gemini_Heatshield_B|bluedog_Gemini_1p5mEndcap|bluedog_Gemini_1p875mLongAdapter|bluedog_Gemini_OneRoomStationModule|bluedog_Gemini_TwoRoomStationModule|bluedog_Gemini_StructuralEndcap|bluedog_GeminiFerry_PressurizedModule]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = structures2
+}
+//advConstruction
+@PART[bluedog_CELV_AdapterTank_1p875m_*|bluedog_Gemini_Crew_C|bluedog_Gemini_Heatshield_AB|bluedog_Gemini_Port_A|bluedog_Gemini_Structure_A|bluedog_Agena_ResupplyContainer|bluedog_Gemini_0p9375mEndcap|bluedog_MOL_CrewTube|bluedog_Gemini_SmallShortAdapter|bluedog_Gemini_StructuralNode|bluedog_GeminiFerry_DockingAdapter]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = advConstruction
+}
+//landing
+//aerodynamicSystems
+@PART[bluedog_Gemini_Heatshield_A|bluedog_gemini_cap]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = aerodynamicSystems
+}
+//subsonicFlight
+//advFlightControl
+@PART[bluedog_Gemini_RCS_A|bluedog_Gemini_RCS_B|bluedog_Gemini_RotationRCS|bluedog_Gemini_TranslationRCS|bluedog_GeminiFerry_RCS*]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = advFlightControl
+}
+//simpleCommandModules
+//reentryPods2
+@PART[bluedog_Gemini_Crew_A]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = reentryPods2
+}
+//recycling
+@PART[bluedog_BigG_CylindricalSM]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = recycling
+}
+//spaceExploration
+@PART[bluedog_Gemini_Service_A|bluedog_Gemini_Service_B|bluedog_Gemini_MalhenaSM|bluedog_Gemini_1p5mShortSegment|bluedog_Gemini_InflatableAirlock]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = spaceExploration
+}
+//miniaturization
+@PART[bluedog_Gemini_RadialAttachPoint]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = miniaturization
+}
+//electrics
+@PART[bluedog_Gemini_DipoleAntenna|bluedog_Gemini_DoubleXAntenna|bluedog_Gemini_WhipAntenna]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = electrics
+}
+//earlyHeatManagement
+//*********************** Tier 6 ***********************
+//precisionPropulsion
+@PART[bluedog_Gemini_Lander_Engine]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = precisionPropulsion
+}
+//heavierRocketry
+//advFuelSystems
+@PART[bluedog_MOL_Propellant|bluedog_Gemini_Lander_SaddleTank]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = advFuelSystems
+}
+//structures3
+//specializedConstruction
+@PART[bluedog_MOL_0p9375mAdapter|bluedog_MOL_1p5mStationSegment|bluedog_MOL_Adapter_15_125|bluedog_MOL_Adapter_1875_15|bluedog_MOL_DockingPort|bluedog_MOL_ThreeWayAdapter|bluedog_MOL_FiveWayAdapter|bluedog_MOL_ForkDockingPort|bluedog_MOL_KISmodule|bluedog_MOL_RingDockingPort|bluedog_Gemini_Lander_LowProfilePort]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = specializedConstruction
+}
+//actuators
+//advLanding
+@PART[bluedog_Gemini_Lander_Leg|bluedog_Gemini_LanderCan]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = advLanding
+}
+//advAerodynamics
+//supersonicFlight
+//efficientFlightSystems
+//specializedControl
+@PART[bluedog_MOL_ControlSegment|bluedog_MOL_RCS|bluedog_MOL_RCS_Alt1|bluedog_MOL_RCS_Alt2|bluedog_MOL_RCS_Alt3]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = specializedControl
+}
+//commandModules
+//reentryPods3
+@PART[bluedog_Gemini_Crew_B]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = reentryPods3
+}
+//hydroponics
+//advExploration
+@PART[bluedog_MOL_Airlock|bluedog_MOL_Camera|bluedog_MOL_EquipmentSection|bluedog_MOL_Hab|bluedog_MOL_Lab|bluedog_MOL_Lab_New|bluedog_MOL_UnpressurizedCargo]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = advExploration
+}
+//precisionEngineering
+//advElectrics
+@PART[bluedog_MOL_rackDish|bluedog_MOL_TrackingAntenna|bluedog_Gemini_LargeFixedArray|bluedog_Gemini_SolarWing|bluedog_MOL_Solar1|bluedog_MOL_Solar2|bluedog_Tianja_LargeFixedSolar|bluedog_Tianja_LargeRotatingSolar|bluedog_Tianja_SmallFixedSolar|bluedog_Tianja_SmallRotatingSolar]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = advElectrics
+}
+//heatManagementSystems
+@PART[bluedog_MOL_LargeRadiator|bluedog_MOL_SmallRadiator]:NEEDS[CommunityTechTree,Bluedog_DB]:BEFORE[zzzUnKerballedStart]
+{
+        @TechRequired = heatManagementSystems
+}
+//*********************** Tier 7 ***********************
+//specializedRocketry7
+//rocketry7
+//largeVolumeContainment
+//composites
+//structures4
+//advMetalworks
+//advActuators
+//heavyLanding
+//heavyAerodynamics
+//highAltitudeFlight
+//unmannedTech
+//heavyCommandModules
+//logistics
+//scienceTech aka scanningTech
+//electronics
+//nuclearPropulsion
+//nuclearPower
+//largeElectrics aka highPowerElectrics
+//*********************** Tier 8 ***********************
+//specializedRocketry8
+//veryHeavyRocketry
+//highPerformanceFuelSystems
+//metaMaterials
+//nanolathing
+//experimentalActuators
+//advancedMotors
+//experimentalAerodynamics
+//hypersonicFlight
+//specializedFlightSystems
+//advUnmanned
+//specializedCommandModules
+//shortTermHabitation
+//advScienceTech
+//ionPropulsion
+//improvedNuclearPropulsion
+//largeNuclearPower aka improvedNuclearPower
+//nuclearFuelSystems
+//advHeatManagement
+//specializedElectrics
+//advSolarTech
+//*********************** Tier 9 ***********************
+//specializedRocketry9
+//experimentalRocketry
+//specializedFuelStorage
+//exoticAlloys 
+//orbitalAssembly
+//offworldManufacturing
+//experimentalMotors
+//aerospaceComposites
+//aerospaceTech
+//largeUnmanned
+//specializedCommandCenters
+//specializedLanders
+//longTermHabitation
+//scientificOutposts
+//experimentalScience
+//advIonPropulsion
+//advNuclearPropulsion
+//advNuclearPower aka highEnergyNuclearPower
+//experimentalElectrics
+//advPVMaterials
+//cuttingEdgeSolarTechnology
+//*********************** Tier 10 ***********************
+//specializedRocketry10
+//giganticRocketry
+//exoticFuelStorage
+//orbitalMegastructures
+//mechatronics
+//advAerospaceEngineering
+//expAircraftEngines
+//artificialIntelligence
+//heavyCommandCenters
+//heavyLanders
+//advLogistics
+//advOffworldMining
+//longTermScienceTech
+//advGriddedThrusters
+//plasmaPropulsion
+//expNuclearPropulsion
+//fusionRockets
+//fusionPower
+//expNuclearPower
+//specializedRadiators
+//highTechElectricalSystems
+//microwavePowerTransmission
+//exoticSolarTech
+//*********************** Tier 11 ***********************
+//specializedRocketry11
+//colossalRocketry
+//extremeFuelStorage
+//colonization
+//resourceExploitation
+//highEnergyScience
+//expGriddedThrusters
+//advEMSystems
+//exoticNuclearPropulsion
+//advancedFusionReactions
+//exoticNuclearPower
+//highPowerElectricalSystems
+//*********************** Tier 12 ***********************
+//advColonization
+//appliedHighEnergyPhysics
+//specializedPlasmaGeneration
+//exoticReactions
+//antimatterPower
+//exoticRadiators
+//experimentalElectricalSystems
+//*********************** Tier 13 ***********************
+//ultraHighEnergyPhysics
+//exoticPlasmaPropulsion
+//quantumReactions
+//unifiedFieldTheory
+//exoticElectricalSystems


### PR DESCRIPTION
I just recognized that in early career all the early unmanned Bluedog Design Bureau rockets are not loadable or buildable in VAB, like for example Vanguard. Then I remembered that I already started in providing a patch 2 years ago...

This is the old one I already mentioned here:
https://forum.kerbalspaceprogram.com/index.php?/topic/181932-18x-unkerballed-start-v110-updated-oct-27-2019/&do=findComment&comment=3709497

There is still stuff missing.
