### PR TITLE
Update liquid engines for 1.12.2 (Swivel and Reliant)

### DIFF
--- a/UnKerballedStart.cfg
+++ b/UnKerballedStart.cfg
@@ -5,7 +5,7 @@
 }
 //
 //Hide Obsolete Parts 
-@PART[solidBooster|solidBooster_sm|rocketNoseCone|mk1pod|mk2LanderCabin|probeCoreHex|probeCoreOcto|probeCoreOcto2|roverBody|probeCoreSphere|HighGainAntenna5|stackDecouplerMini|stackDecoupler|decoupler1-2|size3Decoupler|stackSeparatorMini|stackSeparator|stackSeparatorBig|toroidalFuelTank|Mark1-2Pod|liquidEngineMini|liquidEngine3|liquidEngine2-2|Size3to2Adapter|engineLargeSkipper|ServiceBay_125|ServiceBay_250|Size2LFB]:LAST[zzzUnKerballedStart]
+@PART[solidBooster|solidBooster_sm|rocketNoseCone|mk1pod|mk2LanderCabin|probeCoreHex|probeCoreOcto|probeCoreOcto2|roverBody|probeCoreSphere|HighGainAntenna5|stackDecouplerMini|stackDecoupler|decoupler1-2|size3Decoupler|stackSeparatorMini|stackSeparator|stackSeparatorBig|toroidalFuelTank|Mark1-2Pod|liquidEngineMini|liquidEngine|liquidEngine2|liquidEngine3|liquidEngine2-2|Size3to2Adapter|engineLargeSkipper|ServiceBay_125|ServiceBay_250|Size2LFB]:LAST[zzzUnKerballedStart]
 {
 	@TechRequired = unresearchable
 	@category = none
@@ -138,7 +138,7 @@
 		@TechRequired = propulsionSystems
 }
 //heavyRocketry <= 1.25m
-@PART[solidBooster1-1|liquidEngine|liquidEngine2]:NEEDS[CommunityTechTree]:BEFORE[zzzUnKerballedStart]
+@PART[solidBooster1-1|liquidEngine_v2|liquidEngine2_v2]:NEEDS[CommunityTechTree]:BEFORE[zzzUnKerballedStart]
 {
 		@TechRequired = heavyRocketry
 }

--- a/parts/UKSliquidEngineLVT05.cfg
+++ b/parts/UKSliquidEngineLVT05.cfg
@@ -1,6 +1,6 @@
 // Rescale LV-T30 to .625m
 
-+PART[liquidEngine]:NEEDS[!ReStock]
++PART[liquidEngine_v2]:NEEDS[!ReStock]
  {
 	@name = UKSliquidEngineLVT05
 	@TechRequired = basicRocketry
@@ -32,7 +32,7 @@
 	}
 }
 
-+PART[liquidEngine]:AFTER[ReStock]
++PART[liquidEngine_v2]:AFTER[ReStock]
  {
 	@name = UKSliquidEngineLVT05
 	@TechRequired = basicRocketry

--- a/parts/UKSliquidEngineLVT10.cfg
+++ b/parts/UKSliquidEngineLVT10.cfg
@@ -1,6 +1,6 @@
 // Rescale LV-T45 to .625m
 
-+PART[liquidEngine2]:NEEDS[!ReStock]
++PART[liquidEngine2_v2]:NEEDS[!ReStock]
  {
 	@name = UKSliquidEngineLVT10
 	@TechRequired = generalRocketry
@@ -32,7 +32,7 @@
 	}
 }
 
-+PART[liquidEngine2]:AFTER[ReStock]
++PART[liquidEngine2_v2]:AFTER[ReStock]
  {
 	@name = UKSliquidEngineLVT10
 	@TechRequired = generalRocketry


### PR DESCRIPTION
Update for 1.12.2 (which renamed LVT30 and LVT45 from liquidEngine and liquidEngine2 to liquidEngine_v2 and liquidEngine2_v2 respectively):
- obsoletes v1 versions
- places v2 versions into correct tech level (HeavyRocketry)
- updates definitions for LVT05 and LVT10 to use v2 versions as templates