### PR TITLE
Liquid engines update for 1.12.2

### DIFF
--- a/UnKerballedStart.cfg
+++ b/UnKerballedStart.cfg
@@ -5,7 +5,7 @@
 }
 //
 //Hide Obsolete Parts 
-@PART[solidBooster|solidBooster_sm|rocketNoseCone|mk1pod|mk2LanderCabin|probeCoreHex|probeCoreOcto|probeCoreOcto2|roverBody|probeCoreSphere|HighGainAntenna5|stackDecouplerMini|stackDecoupler|decoupler1-2|size3Decoupler|stackSeparatorMini|stackSeparator|stackSeparatorBig|toroidalFuelTank|Mark1-2Pod|liquidEngineMini|liquidEngine3|liquidEngine2-2|Size3to2Adapter|engineLargeSkipper|ServiceBay_125|ServiceBay_250|Size2LFB]:LAST[zzzUnKerballedStart]
+@PART[solidBooster|solidBooster_sm|rocketNoseCone|mk1pod|mk2LanderCabin|probeCoreHex|probeCoreOcto|probeCoreOcto2|roverBody|probeCoreSphere|HighGainAntenna5|stackDecouplerMini|stackDecoupler|decoupler1-2|size3Decoupler|stackSeparatorMini|stackSeparator|stackSeparatorBig|toroidalFuelTank|Mark1-2Pod|liquidEngineMini|liquidEngine|liquidEngine2|liquidEngine3|liquidEngine2-2|Size3to2Adapter|engineLargeSkipper|ServiceBay_125|ServiceBay_250|Size2LFB]:LAST[zzzUnKerballedStart]
 {
 	@TechRequired = unresearchable
 	@category = none
@@ -138,7 +138,7 @@
 		@TechRequired = propulsionSystems
 }
 //heavyRocketry <= 1.25m
-@PART[solidBooster1-1|liquidEngine|liquidEngine2]:NEEDS[CommunityTechTree]:BEFORE[zzzUnKerballedStart]
+@PART[solidBooster1-1|liquidEngine_v2|liquidEngine2_v2]:NEEDS[CommunityTechTree]:BEFORE[zzzUnKerballedStart]
 {
 		@TechRequired = heavyRocketry
 }

--- a/parts/UKSliquidEngineLVT05.cfg
+++ b/parts/UKSliquidEngineLVT05.cfg
@@ -1,7 +1,11 @@
 // Rescale LV-T30 to .625m
 
-+PART[liquidEngine_v2]:NEEDS[!ReStock]
++PART[liquidEngine]:NEEDS[!ReStock]
  {
+	-TechHidden = false // 'liquidEngine' is hidden and misses cost/category definitions @ 1.12.2
+	@category = Engine   
+	@entryCost = 3200   
+
 	@name = UKSliquidEngineLVT05
 	@TechRequired = basicRocketry
 	@node_stack_top = 0.0, 7, 0.0, 0.0, 1.0, 0.0, 0
@@ -32,8 +36,12 @@
 	}
 }
 
-+PART[liquidEngine_v2]:AFTER[ReStock]
++PART[liquidEngine]:AFTER[ReStock]
  {
+	-TechHidden = false // 'liquidEngine' is hidden and misses cost/category definitions @ 1.12.2
+	@category = Engine   
+	@entryCost = 3200   
+
 	@name = UKSliquidEngineLVT05
 	@TechRequired = basicRocketry
 	@node_stack_top = 0.0, 0.885, 0.0, 0.0, 0.25, 0.0, 0, 1

--- a/parts/UKSliquidEngineLVT05.cfg
+++ b/parts/UKSliquidEngineLVT05.cfg
@@ -1,6 +1,6 @@
 // Rescale LV-T30 to .625m
 
-+PART[liquidEngine]:NEEDS[!ReStock]
++PART[liquidEngine_v2]:NEEDS[!ReStock]
  {
 	@name = UKSliquidEngineLVT05
 	@TechRequired = basicRocketry
@@ -32,7 +32,7 @@
 	}
 }
 
-+PART[liquidEngine]:AFTER[ReStock]
++PART[liquidEngine_v2]:AFTER[ReStock]
  {
 	@name = UKSliquidEngineLVT05
 	@TechRequired = basicRocketry

--- a/parts/UKSliquidEngineLVT10.cfg
+++ b/parts/UKSliquidEngineLVT10.cfg
@@ -1,7 +1,11 @@
 // Rescale LV-T45 to .625m
 
-+PART[liquidEngine2_v2]:NEEDS[!ReStock]
++PART[liquidEngine2]:NEEDS[!ReStock]
  {
+	-TechHidden = false // 'liquidEngine2' is hidden and misses cost/category definitions @ 1.12.2
+	@category = Engine   
+	@entryCost = 3500   
+
 	@name = UKSliquidEngineLVT10
 	@TechRequired = generalRocketry
 	@node_stack_top = 0.0, 7, 0.0, 0.0, 1.0, 0.0, 0
@@ -32,8 +36,12 @@
 	}
 }
 
-+PART[liquidEngine2_v2]:AFTER[ReStock]
++PART[liquidEngine2]:AFTER[ReStock]
  {
+	-TechHidden = false // 'liquidEngine2' is hidden and misses cost/category definitions @ 1.12.2
+	@category = Engine   
+	@entryCost = 3500   
+
 	@name = UKSliquidEngineLVT10
 	@TechRequired = generalRocketry
 	@entryCost *= .5

--- a/parts/UKSliquidEngineLVT10.cfg
+++ b/parts/UKSliquidEngineLVT10.cfg
@@ -1,6 +1,6 @@
 // Rescale LV-T45 to .625m
 
-+PART[liquidEngine2]:NEEDS[!ReStock]
++PART[liquidEngine2_v2]:NEEDS[!ReStock]
  {
 	@name = UKSliquidEngineLVT10
 	@TechRequired = generalRocketry
@@ -32,7 +32,7 @@
 	}
 }
 
-+PART[liquidEngine2]:AFTER[ReStock]
++PART[liquidEngine2_v2]:AFTER[ReStock]
  {
 	@name = UKSliquidEngineLVT10
 	@TechRequired = generalRocketry


### PR DESCRIPTION
Update for 1.12.2 (which renamed LVT30 and LVT45 from liquidEngine and liquidEngine2 to liquidEngine_v2 and liquidEngine2_v2 respectively).
This patch:
-   hides v1 versions of LVT30 and LVT45 (probably not needed; just in case)
-   places v2 versions of LVT30 and LVT45 into correct tech level (HeavyRocketry)
-   patches definitions for LVT05 and LVT10 (both prototypes are missing category and entryCost in 1.12.2)
