### PR TITLE
Fix version file syntax error

### DIFF
--- a/.github/workflows/AVC-VersionFileValidator.yml
+++ b/.github/workflows/AVC-VersionFileValidator.yml
@@ -1,0 +1,19 @@
+name: Validate AVC .version files
+on:
+  push:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  validate_version_files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Validate files
+        uses: DasSkelett/AVC-VersionFileValidator@master

--- a/UnKerballedStart.version
+++ b/UnKerballedStart.version
@@ -3,4 +3,5 @@
 "DOWNLOAD":"https://github.com/theonegalen/UnKerballedStart/releases/download/v1.3.1/UnKerballedStart-1.3.1.zip",
 "CHANGE_LOG_URL":"https://github.com/theonegalen/UnKerballedStart/releases",
 "VERSION":{"MAJOR":1,"MINOR":3,"PATCH":1,"BUILD":0},
-"KSP_VERSION":{"MAJOR":1,"MINOR":12,"PATCH":3},
+"KSP_VERSION":{"MAJOR":1,"MINOR":12,"PATCH":3}
+}


### PR DESCRIPTION
Hi @theonegalen, the latest release has not updated into CKAN because the version file has a syntax error (extra comma, missing close brace).

![image](https://user-images.githubusercontent.com/1559108/150611668-9cdb1692-2097-40b4-b642-735da4a4b8ce.png)

This pull request fixes it.
It also adds a GitHub workflow file that will automatically validate the version file when it's changed, to help prevent this from happening again.

https://github.com/DasSkelett/AVC-VersionFileValidator