### PR TITLE
Fix 1.25m Engine Plate Placement

### DIFF
--- a/Mod Support/MakingHistory.cfg
+++ b/Mod Support/MakingHistory.cfg
@@ -25,7 +25,7 @@
 		@TechRequired = structures1p5
 }
 //basicConstruction
-@PART[EnginePlate1p5|Decoupler_1p5|Size1p5_Size1_Adapter_02|Size1p5_Size0_Adapter_01|Size1p5_Tank_01]:NEEDS[CommunityTechTree,SquadExpansion/MakingHistory]:BEFORE[zzzUnKerballedStart]
+@PART[EnginePlate5|Decoupler_1p5|Size1p5_Size1_Adapter_02|Size1p5_Size0_Adapter_01|Size1p5_Tank_01]:NEEDS[CommunityTechTree,SquadExpansion/MakingHistory]:BEFORE[zzzUnKerballedStart]
 {
 	@TechRequired = basicConstruction
 }


### PR DESCRIPTION
Fix a typo causing the MH 1.25m engine plate to show up in the wrong tier